### PR TITLE
Provide an additional 'message-file' as action output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,6 +30,8 @@ inputs:
 outputs:
   message:
     description: 'The schema check output as markdown message.'
+  message-file:
+    description: 'The schema check output as markdown file'
 
 runs:
   using: node20

--- a/src/main.ts
+++ b/src/main.ts
@@ -162,6 +162,10 @@ export async function run(): Promise<void> {
 
       core.info('Setting output message.')
       core.setOutput('message', message)
+      const outputFile = 'schema-check-message.md'
+      await writeFile(outputFile, message, 'utf-8')
+      core.setOutput('message-file', outputFile)
+      core.info(`Message written to ${outputFile}`)
       core.info('Setting action summary.')
       await core.summary.addRaw(summary).write()
     }


### PR DESCRIPTION
Currently the message of the json check is written to a message string.

This works for showing the results in a job summary page, but it may pose problems for downstream workflow steps to further work with the message content, such as

- very long content may not be usable as input for other actions (see for example https://github.com/peter-evans/create-or-update-comment/issues/234)
- message usually contains something like `` ```diff ...``` ``, which might break all downstream steps that try to put the message content into a file via shell script (because the content in backticks might be interpreted as a command)
- messages may contain other troublesome characters (such as single quotes etc) which makes the last point even more difficult to address.

To avoid such issues with the message string, this PR proposes to additionally write the message to an md file available for further workflow steps.